### PR TITLE
Avoid ambiguity in documentation of installation process

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Wrapper for Matomo (aka. Piwik) analytics tracker for Angular 5+ applications.
 
 Download directly from github and place the src files in your Angular 5+ application. 
 
-##npm install
+## npm install
 
 ```npm install --save ngx-matomo```
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ Download directly from github and place the src files in your Angular 5+ applica
 
 ```npm install --save ngx-matomo```
 
+## Adding Matomo into to your Angular application
+
+You can add Matomo either via script tag or using the MatomoInjector in your root component.
 
 ### Adding Matomo into your application via Script Tag.
 


### PR DESCRIPTION
First of all thank you for this project, it helped me a lot!

I noticed an ambiguity in the readme when I added Matomo to my application: I first understood that both the script tag and the MatomoInjector are needed, while only one will suffice. This commit adds a paragraph that tries to clarify that.