### PR TITLE
feat(injector): Add optional skipTrackingInitialPageView init parameter

### DIFF
--- a/projects/ngx-matomo/src/lib/matomo-injector.service.ts
+++ b/projects/ngx-matomo/src/lib/matomo-injector.service.ts
@@ -36,10 +36,13 @@ export class MatomoInjector {
    * @param url URL of the Matomo instance to connect to.
    * @param id SiteId for this application/site.
    * @param [scriptUrl] Optional URL for the `piwik.js`/`matomo.js` script in case it is not at its default location.
+   * @param [skipTrackingInitialPageView] Optional boolean which, if true, will prevent tracking the initial page as part of init
    */
-  init(url: string, id: number, scriptUrl?: string) {
+  init(url: string, id: number, scriptUrl?: string, skipTrackingInitialPageView?: boolean) {
     if (isPlatformBrowser(this.platformId)) {
-      window._paq.push(['trackPageView']);
+      if (!skipTrackingInitialPageView) {
+        window._paq.push(['trackPageView']);
+      }
       window._paq.push(['enableLinkTracking']);
       (() => {
         const u = url;


### PR DESCRIPTION
### Summary

This PR adds an additional (optional) parameter to the `init()` function of the injector service which allows the user to initialise Matomo _without_ automatically tracking the initial page load. Behaviour is unchanged by default, but if the user chooses to pass `true` to the new parameter it becomes possible to avoid tracking the initial page load - giving the user more control over when and how the first page event gets tracked.

### Detailed description of use case
In our application, we needed to:
- subscribe to the stream of navigation events from the router
- extract specific information about each route after navigation (this could be any business logic)
- track the page view, along with the custom dimensions that have been extracted

By subscribing to the Angular router's `events` observable, the pipeline above worked nicely, but we found that ngx-matomo was also automatically capturing the initial page load as part of the process of initialising ngx-matomo. As a result, the events in the Matomo visitor log were inconsistent and the first log for each visit excluded the custom dimensions because they originated from the automatic call to `trackPageView` inside ngx-matomo. 

I think giving the user the ability to disable this functionality would be useful in situations where more control is needed over the page tracking, so am hoping that this contribution would enhance the library.